### PR TITLE
Fix 2017-01-30-ecmascript-proposals-status.md

### DIFF
--- a/_posts/2017/2017-01-30-ecmascript-proposals-status.md
+++ b/_posts/2017/2017-01-30-ecmascript-proposals-status.md
@@ -14,7 +14,7 @@ tags:
 
 The changes of proposal's status @ [56th meeting of Ecma TC39](https://github.com/tc39/agendas/blob/master/2017/01.md)
 
-New 5 proposals are arrived.
+4 new proposals are arrived.
 
 | Proposal                                 | Stage       |
 | ---------------------------------------- | ----------- |
@@ -23,10 +23,9 @@ New 5 proposals are arrived.
 | [Error Stacks](https://github.com/ljharb/proposal-error-stacks "Error Stacks") | NaN->1      |
 | [Math.signbit](http://jfbastien.github.io/papers/Math.signbit.html "Math.signbit") | NaN->1      |
 | [Realms API](https://github.com/tc39/proposal-realms "Realms API") | NaN->1      |
-| [Math.signbit](http://jfbastien.github.io/papers/Math.signbit.html "Math.signbit") | NaN->1      |
 | [do expression](https://gist.github.com/dherman/1c97dfb25179fa34a41b5fff040f9879) | 0->1        |
 | [RegExp Named Capture Groups](https://github.com/tc39/proposal-regexp-named-groups "RegExp Named Capture Groups") | 1->2        |
-| [Shared memory and atomics](https://github.com/tc39/ecmascript_sharedmem "Shared memory and atomics") | 4->ES2017   |
+| [Shared memory and atomics](https://github.com/tc39/ecmascript_sharedmem "Shared memory and atomics") | 3->ES2017   |
 
 Other proposal's staus 
 


### PR DESCRIPTION
- remove duplicate entry for `Math.signbit` from the list
- fix previous stage of `Shared memory and atomics` (it changed from `3` to `4` (which equals `ES2017` at the moment))